### PR TITLE
Adds CSRF token handling for Apollo

### DIFF
--- a/lib/apollo-client.ts
+++ b/lib/apollo-client.ts
@@ -40,11 +40,15 @@ function createApolloClient(context = {}) {
 
 	// automatically add the CSRF token to headers
 	const csrfMiddleware = new ApolloLink((operation, forward) => {
-		operation.setContext(({ headers = {} }) => ({
-			headers: {
-				"X-Csrf-Token": localStorage.getItem("csrf-token"),
-			}
-		}));
+		const csrfTokenValue = localStorage.getItem("csrf-token")
+
+		if(csrfTokenValue){
+			operation.setContext(({ headers = {} }) => ({
+				headers: {
+					"X-Csrf-Token": csrfTokenValue,
+				}
+			}));
+		}
 
 		return forward(operation);
 	})

--- a/lib/apollo-client.ts
+++ b/lib/apollo-client.ts
@@ -21,6 +21,7 @@ function createApolloClient(context = {}) {
 		},
 	});
 
+	// automatically save the CSRF token from responses to localStorage
 	const saveCsrfTokenMiddleware = new ApolloLink((operation, forward) => {
 		return forward(operation).map((response) => {
 			const context = operation.getContext();
@@ -37,8 +38,8 @@ function createApolloClient(context = {}) {
 		});
 	});
 
+	// automatically add the CSRF token to headers
 	const csrfMiddleware = new ApolloLink((operation, forward) => {
-		// add the CSRF token to headers
 		operation.setContext(({ headers = {} }) => ({
 			headers: {
 				"X-Csrf-Token": localStorage.getItem("csrf-token"),


### PR DESCRIPTION
Depends on: https://github.com/goinvo/staffplan_redux/pull/133
One part that closes: https://github.com/goinvo/staffplan_redux/issues/110

Adds some Apollo middleware to:

* set a CSRF token value from the backend
* automatically set a CSRF token value if one's present

for all GraphQL requests.
