### PR TITLE
adjusted mystaffplan underline in header

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -12,18 +12,23 @@ import { FaSearch } from "react-icons/fa";
 
 const Navbar: React.FC = () => {
 	const { viewer } = useUserDataContext();
+	const fullPathName = usePathname();
 	const pathname = usePathname().split("/")[1];
 	const activeTab = "navbar-border-accent border-b-2";
 	if (!viewer) return <LoadingSpinner />;
 	const myPlanUrl = () => {
-		return encodeURIComponent(viewer.id)
+		return encodeURIComponent(viewer.id);
 	};
+	const myStaffPlanURL = new RegExp(`^\\/people\\/${viewer.id}$`);
+	const myStaffPlanCheck = fullPathName.match(myStaffPlanURL);
 	return (
 		<nav className="navbar bg-gray-100 px-4 h-14 flex justify-between items-center">
 			<div className="flex items-center space-x-4 h-full">
 				<Link
 					href={`/people/${myPlanUrl()}`}
-					className="navbar-text-accent hover:underline"
+					className={`navbar-text-accent ${
+						myStaffPlanCheck ? activeTab : "hover:underline"
+					}`}
 				>
 					My StaffPlan
 				</Link>
@@ -38,22 +43,24 @@ const Navbar: React.FC = () => {
 				<Link
 					href="/people"
 					className={`flex h-full justify-between items-center ${
-						pathname === "people" ? activeTab : "hover:underline"
+						pathname === "people" && !myStaffPlanCheck
+							? activeTab
+							: "hover:underline"
 					}`}
 				>
 					People
 				</Link>
 			</div>
 			<div className="flex justify-center items-center actionbar-text-search">
-					<div className="w-4 h-4 flex mr-2" aria-label="search">
-						<FaSearch/>
-					</div>
-					<input
-						type="text"
-						placeholder="Search"
-						className="flex bg-transparent py-1 border-none border-gray-300"
-					/>
+				<div className="w-4 h-4 flex mr-2" aria-label="search">
+					<FaSearch />
 				</div>
+				<input
+					type="text"
+					placeholder="Search"
+					className="flex bg-transparent py-1 border-none border-gray-300"
+				/>
+			</div>
 			<div className="flex items-center space-x-4 py-4">
 				<div className="h-4 w-4">
 					<ChatBubbleBottomCenterTextIcon />


### PR DESCRIPTION
Closes #73 

![image](https://github.com/goinvo/staffplan-next-app/assets/114195647/a1835536-014f-4d1d-9e8e-14c5449b9b7d)

myStaffPlan is now underlined when it is the active page.