### PR TITLE
added missing domain in domains array staffplan.com

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ const nextConfig = {
 		];
 	},
 	images:{
-		domains: ['secure.gravatar.com','www.gravatar.com','staffplan.fermion.dev','localhost'],
+		domains: ['secure.gravatar.com','www.gravatar.com','staffplan.fermion.dev','localhost', 'www.staffplan.com'],
 		remotePatterns:[
 			{
 				protocol: 'https',


### PR DESCRIPTION
the last PR didn't seem to do it. I believe this will fix it, the avatars that load correctly are coming from secure.gravatar that was already in our list of image domains, and previoulsy they were staffplan.fermion.dev, so until prod we hadn't been receiving images from staffplan.com but now we are so I think it was just missing that domain. This should do the trick this time I'm pretty sure.