### PR TITLE
allow for null hours to be submitted

### DIFF
--- a/app/components/projectAssignment/workWeekInput.tsx
+++ b/app/components/projectAssignment/workWeekInput.tsx
@@ -206,7 +206,7 @@ export const WorkWeekInput = ({
 							onChange={handleChange}
 							onBlur={(e) => {
 								handleBlur("estimatedHours");
-								if (dirty && values.estimatedHours) {
+								if (dirty) {
 									upsertWorkWeekValues(values);
 								}
 							}}
@@ -221,7 +221,7 @@ export const WorkWeekInput = ({
 							onChange={handleChange}
 							onBlur={(e) => {
 								handleBlur("actualHours");
-								if (dirty && values.actualHours) {
+								if (dirty) {
 									upsertWorkWeekValues(values);
 								}
 							}}

--- a/app/components/userAssignment/workWeekInput.tsx
+++ b/app/components/userAssignment/workWeekInput.tsx
@@ -205,7 +205,7 @@ export const WorkWeekInput = ({
 						onChange={handleChange}
 						onBlur={(e) => {
 							handleBlur("estimatedHours");
-							if (dirty && values.estimatedHours) {
+							if (dirty) {
 								upsertWorkWeekValues(values);
 							}
 						}}
@@ -221,7 +221,7 @@ export const WorkWeekInput = ({
 							onChange={handleChange}
 							onBlur={(e) => {
 								handleBlur("actualHours");
-								if (dirty && values.actualHours) {
+								if (dirty) {
 									upsertWorkWeekValues(values);
 								}
 							}}


### PR DESCRIPTION
This allows for `workWeeks` to be submitted with no value but ensures the value has changed. Previously no change was made if someone just erases the hours in the input. Now when they are erased the mutation fires turning them to zero. 